### PR TITLE
Midlertidig filtrerer vekk avtaler som er avsluttet.

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakhendelseaktivitetsplan/kafka/AvtaleHendelseConsumer.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakhendelseaktivitetsplan/kafka/AvtaleHendelseConsumer.kt
@@ -12,6 +12,7 @@ import java.time.Duration
 import java.time.LocalDateTime
 import kotlinx.coroutines.*
 import no.nav.arbeidsgiver.tiltakhendelseaktivitetsplan.database.Database
+import java.time.LocalDate
 import java.util.UUID
 
 class AvtaleHendelseConsumer(
@@ -39,6 +40,14 @@ class AvtaleHendelseConsumer(
                 }
                 if (!melding.tiltakstype.skalTilAktivitetsplan) {
                     log.info("melding med tiltakstype ${melding.tiltakstype} skal ikke til aktivitetsplan")
+                    consumer.commitAsync()
+                    return@forEach
+                }
+
+                // Hvis statusendring, filtrer evt vekk ikke aktive avtaler!
+                // TODO: Midlertidig kode. Dett gjelder kun når vi leser inn alle avtalehendelse meldinger.
+                if(melding.avtaleStatus === AvtaleStatus.AVSLUTTET) {
+                    log.info("MIDLERTIDIG - Avtalen er avsluttet, skal ikke til aktivitetsplan")
                     consumer.commitAsync()
                     return@forEach
                 }

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakhendelseaktivitetsplan/kafka/AvtaleHendelseMelding.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakhendelseaktivitetsplan/kafka/AvtaleHendelseMelding.kt
@@ -7,21 +7,21 @@ import java.time.LocalDateTime
 import java.util.*
 
 data class AvtaleHendelseMelding(
-    var hendelseType: HendelseType,
-    var tiltakstype: Tiltakstype,
-    var avtaleStatus: AvtaleStatus,
-    var startDato: LocalDate?,
-    var sluttDato: LocalDate?,
-    var bedriftNavn: String?,
-    var bedriftNr: String,
-    var stillingstittel: String?,
-    var stillingprosent: Int?,
-    var avtaleInngått: LocalDateTime?,
-    var utførtAv: String,
-    var utførtAvRolle: AvtaleHendelseUtførtAvRolle,
-    var deltakerFnr: String,
-    var avtaleId: UUID,
-    var avtaleNr: Int,
-    var sistEndret: Instant,
-    var veilederNavIdent: String?
+    val hendelseType: HendelseType,
+    val tiltakstype: Tiltakstype,
+    val avtaleStatus: AvtaleStatus,
+    val startDato: LocalDate?,
+    val sluttDato: LocalDate?,
+    val bedriftNavn: String?,
+    val bedriftNr: String,
+    val stillingstittel: String?,
+    val stillingprosent: Int?,
+    val avtaleInngått: LocalDateTime?,
+    val utførtAv: String,
+    val utførtAvRolle: AvtaleHendelseUtførtAvRolle,
+    val deltakerFnr: String,
+    val avtaleId: UUID,
+    val avtaleNr: Int,
+    val sistEndret: Instant,
+    val veilederNavIdent: String?
 )


### PR DESCRIPTION
Filtrerer vekk avsluttede avtaler for når vi leser inn hele topicen. Vi må fjerne det før dagen er omme 01.02 slik at statusendringer blir fanget opp på avtaler som går til avsluttet.

Dette gjøres fordi vi ikke ønsker å sende meldinger på masse gamle avsluttede tiltak til aktivitetsplanen.
Denne filtreringen må fjernes igjen etter vi har lest inn hele topicen i prod, fordi vi må ha med meldinger om avtaler som endrer status til avsluttet på normalt vis.

Gjort om alle fleter i Kafka-meldingen fra tiltaksgjennomforing-api til å være val. De skal ikke endres på.