### PR TITLE
bruker instant.now hvis det er statusendringer

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakhendelseaktivitetsplan/kafka/AktivitetsKort.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakhendelseaktivitetsplan/kafka/AktivitetsKort.kt
@@ -36,7 +36,7 @@ data class AktivitetsKort(
                 //  beskrivelse = "Dette er en beskrivelse",
                 aktivitetStatus = aktivitetStatusFraAvtaleStatus(melding.avtaleStatus),
                 endretAv = endretAvAktivitetsplanformat(melding.utførtAv, melding.utførtAvRolle),
-                endretTidspunkt = melding.sistEndret,
+                endretTidspunkt = if (melding.hendelseType == HendelseType.STATUSENDRING) Instant.now() else melding.sistEndret,
                 avtaltMedNav = melding.veilederNavIdent != null,
                 oppgave = null,
                 handlinger = listOf(

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakhendelseaktivitetsplan/kafka/AktivitetsplanProducer.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakhendelseaktivitetsplan/kafka/AktivitetsplanProducer.kt
@@ -42,7 +42,7 @@ class AktivitetsplanProducer(
             aktivitetsKort)
         val meldingJson = mapper.writeValueAsString(aktivitetsplanMelding)
 
-        sjekkSistEndret(aktivitetsKort.endretTidspunkt)
+        sjekkEndretTidspunkt(aktivitetsKort.endretTidspunkt)
 
         if(!schema.validate(meldingJson))  {
             val output = schema.validateBasic(meldingJson)
@@ -104,7 +104,7 @@ class AktivitetsplanProducer(
         }
     }
 
-    private fun sjekkSistEndret(sistEndret: Instant) {
+    private fun sjekkEndretTidspunkt(sistEndret: Instant) {
         if (sistEndret.isBefore(Instant.now().minus(30, java.time.temporal.ChronoUnit.MINUTES))) {
             log.warn("Sist endret ($sistEndret) som vi sender til aktivitetsplanen som endretTidspiunkt er mer enn 30 minutter gammel!")
         }


### PR DESCRIPTION
I Aktivietsplan-meldinger som sendes til aktivitetsplanen så oppgir vi et `endretTidspunkt`-felt.
I dette feltet har vi puttet inn `sistEndret`-feltet som vi får fra avtalehendelsen som kommer fra tiltaksgjennomforing.
Dette `sistEndret`-tidspunktet blir oppdatert når noen (veileder/arbeidsgiver/deltaker) gjør en endring på en avtale, men ikke når det skjer en statusendring.


Dette da statusendring ikke er en faktisk endring av avtalen. I avtaleløsningen blir statuser utledet gjennom kode. For å kunne sende ut meldinger på når statuser endrer seg har tiltaksgjennomforing en scheduled-jobb som går 1 gang i døgnet og sjekker om det at det ble en ny dato har påvirket statusen (passert startdato/sluttdato).
