### PR TITLE
endring av datatype på antallDagerPerUke felt fra kafka melding

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakhendelseaktivitetsplan/kafka/AvtaleHendelseMelding.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakhendelseaktivitetsplan/kafka/AvtaleHendelseMelding.kt
@@ -15,7 +15,7 @@ data class AvtaleHendelseMelding(
     val bedriftNavn: String?,
     val bedriftNr: String,
     val stillingstittel: String?,
-    val stillingprosent: Int?,
+    val stillingprosent: Double?,
     val avtaleInngått: LocalDateTime?,
     val utførtAv: String,
     val utførtAvRolle: AvtaleHendelseUtførtAvRolle,


### PR DESCRIPTION
Eneste stedet den er i bruk er her, vil nok fungere fint med double også.
`lagAttributt(label = "Antall dager per uke", verdi = melding.antallDagerPerUke?.toString())
`