### PR TITLE
endret logikk for tolkning av hva som er gammel mentoravtale

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakhendelseaktivitetsplan/kafka/AktivitetsKort.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakhendelseaktivitetsplan/kafka/AktivitetsKort.kt
@@ -54,7 +54,8 @@ data class AktivitetsKort(
         private fun lagDetaljer(melding: AvtaleHendelseMelding): List<Attributt> {
             if (melding.tiltakstype == Tiltakstype.MENTOR) {
                 val mentorBeregninger = listOf(melding.arbeidsgiverKontonummer, melding.otpSats, melding.arbeidsgiveravgift, melding.feriepengesats)
-                val mentorTimeEnhet = if (mentorBeregninger.any { it != null }) "måned" else "uke"
+                val erGammelAvtale = melding.erAvtaleInngått() && mentorBeregninger.all { it == null }
+                val mentorTimeEnhet = if (!erGammelAvtale) "måned" else "uke"
 
                 return listOf(
                     lagAttributt(label = "Arbeidsgiver", verdi = melding.bedriftNavn),

--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakhendelseaktivitetsplan/kafka/AvtaleHendelseMelding.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakhendelseaktivitetsplan/kafka/AvtaleHendelseMelding.kt
@@ -34,4 +34,8 @@ data class AvtaleHendelseMelding(
     val feriepengesats: BigDecimal?,
     val arbeidsgiveravgift: BigDecimal?,
     val otpSats: Double?
-)
+) {
+    fun erAvtaleInngått(): Boolean {
+        return avtaleInngått != null
+    }
+}


### PR DESCRIPTION
mentorberegningsfelter er ikke fylt ut ved opprettelse av mentor-avtale. Hvis man kun fyller ut antall timer med mentor per måned i avtalen, uten å fylle ut de økonomiske detaljene vil det står per uke i aktivitetskortet.

Endrer logikken til å sammenfalle mer med det vi har gjort i oppsummeringen i avtalen - hvis avtalen er inngått og ingen økonomifelter er fylt ut, er det en gammel avtale og vi viser "per uke", ellers "per måned".