### PR TITLE
Fiks bygg etter postgres-oppgradering

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,11 @@
                                 <manifest>
                                     <mainClass>no.nav.arbeidsgiver.tiltakhendelseaktivitetsplan.AppKt</mainClass>
                                 </manifest>
+                                <manifestEntries>
+                                    <!-- Ble nødvendig etter oppgradering av postgres-driver (nyere versjon av bibliotek
+                                    ble en multi-release, som smitter over til vår app) -->
+                                    <Multi-Release>true</Multi-Release>
+                                </manifestEntries>
                             </archive>
                             <descriptorRefs>
                                 <descriptorRef>jar-with-dependencies</descriptorRef>


### PR DESCRIPTION
Nyere versjoner av postgres-driveren (f.o.m 42.7.9) har blitt en "multi-release", som tydeligvis betyr at biblioteket støtter flere java-versjoner.

Det betyr at vi må gjøre om vår egen jar til en multi-release også.