### PR TITLE
Fjern H2, bruk testcontainers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
         <java.version>25</java.version>
         <kotlin.version>2.3.21</kotlin.version>
         <ktor.version>2.3.12</ktor.version>
+        <testcontainers.version>1.20.6</testcontainers.version>
     </properties>
 
     <repositories>
@@ -141,7 +142,13 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>kafka</artifactId>
-            <version>1.16.0</version>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -214,12 +221,6 @@
             <groupId>com.github.seratch</groupId>
             <artifactId>kotliquery</artifactId>
             <version>1.9.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <version>2.3.232</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakhendelseaktivitetsplan/AppTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakhendelseaktivitetsplan/AppTest.kt
@@ -16,7 +16,6 @@ import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
-import org.h2.tools.Server
 import org.junit.jupiter.api.Disabled
 import org.testcontainers.containers.KafkaContainer
 import org.testcontainers.utility.DockerImageName
@@ -68,7 +67,6 @@ class AppTest {
 
             val scope = CoroutineScope(Dispatchers.Default)
             val app = App(avtaleHendelseConsumer, aktivitetsplanFeilConsumer, database)
-            Server.createWebServer().start()
 
             val result = withTimeoutOrNull(10.seconds) { // Timeout etter (10 sekunder)
                 scope.launch {// UTEN SCOPE VIL FEIL CONSUMER ALDRI KUNNE LESE FRA database

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakhendelseaktivitetsplan/LokalApp.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakhendelseaktivitetsplan/LokalApp.kt
@@ -8,7 +8,6 @@ import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.Producer
-import org.h2.tools.Server
 
 suspend fun main() {
     val schema = JSONSchema.parseFile("src/main/resources/schema.yml")
@@ -22,7 +21,5 @@ suspend fun main() {
     val aktivitetsplanFeilConsumer = FeilConsumer(consumer, database)
 
     val app = App(avtaleHendelseConsumer, aktivitetsplanFeilConsumer, database)
-    val server = Server.createWebServer().start()
-    println("\n H2 Started med status: ${server.status} \n")
     app.start()
 }

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakhendelseaktivitetsplan/database/DatabaseTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakhendelseaktivitetsplan/database/DatabaseTest.kt
@@ -3,6 +3,7 @@ package no.nav.arbeidsgiver.tiltakhendelseaktivitetsplan.database
 import no.nav.arbeidsgiver.tiltakhendelseaktivitetsplan.kafka.AvtaleId
 import no.nav.arbeidsgiver.tiltakhendelseaktivitetsplan.kafka.AvtaleStatus
 import no.nav.arbeidsgiver.tiltakhendelseaktivitetsplan.kafka.HendelseType
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 import java.util.*
@@ -11,6 +12,13 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class DatabaseTest {
+
+    private val database = Database(testDataSource)
+
+    @BeforeEach
+    fun setup() {
+        resetTestDatabase()
+    }
 
     val entitet = AktivitetsplanMeldingEntitet(
         id = UUID.fromString("6cb7a6ce-59d7-11ed-9b6a-0242ac120002"),
@@ -75,7 +83,6 @@ class DatabaseTest {
 
     @Test
     fun skal_kunne_lagre_og_hente_entiteter() {
-        val database = Database(testDataSource)
         database.lagreNyAktivitetsplanMeldingEntitet(entitet)
         val aktivitetsplanMeldingEntitet = database.hentEntitet(UUID.fromString("6cb7a6ce-59d7-11ed-9b6a-0242ac120002"))
         val aktivitetsplanMeldingEntitetHentetMedAvtaleId = database.hentEntitet(AvtaleId("251c5828-59dc-11ed-9b6a-0242ac120002"))
@@ -86,7 +93,6 @@ class DatabaseTest {
 
     @Test
     fun skal_lunne_lagre_flere_meldinger_med_samme_avtale_id() {
-        val database = Database(testDataSource)
         database.lagreNyAktivitetsplanMeldingEntitet(entitet3medSammeAvtaleId)
         database.lagreNyAktivitetsplanMeldingEntitet(entitet4medSammeAvtaleId)
         val aktivitetsplanMeldingEntitetHentetMedAvtaleId = database.hentEntitet(AvtaleId("64e80700-c9b9-4e03-9741-7566eb0542e7"))
@@ -95,7 +101,6 @@ class DatabaseTest {
 
     @Test
     fun skal_kunne_oppdatere_entitet_til_sendt() {
-        val database = Database(testDataSource)
         database.lagreNyAktivitetsplanMeldingEntitet(entitet2)
         database.settEntitetTilSendt(UUID.fromString("66276156-9bc6-11ed-a8fc-0242ac120002"), 1337L)
         val aktivitetsplanMeldingEntitet = database.hentEntitet(UUID.fromString("66276156-9bc6-11ed-a8fc-0242ac120002"))
@@ -108,7 +113,6 @@ class DatabaseTest {
 
     @Test
     fun skal_kunne_lagre_feilede_hendelse_i_database() {
-        val database = Database(testDataSource)
         database.lagreNyHendelseMeldingFeiletEntitet(feiletEntitet)
     }
 

--- a/src/test/kotlin/no/nav/arbeidsgiver/tiltakhendelseaktivitetsplan/database/dataSourceLocal.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/tiltakhendelseaktivitetsplan/database/dataSourceLocal.kt
@@ -1,11 +1,31 @@
 package no.nav.arbeidsgiver.tiltakhendelseaktivitetsplan.database
 
 import kotliquery.HikariCP
+import kotliquery.queryOf
+import kotliquery.sessionOf
+import kotliquery.using
+import org.testcontainers.containers.PostgreSQLContainer
+
+private val postgres14Container = PostgreSQLContainer<Nothing>("postgres:14")
+    .apply {
+        withDatabaseName("tiltak_hendelse_aktivitetsplan_test")
+        withUsername("test")
+        withPassword("test")
+        start()
+    }
 
 val testDataSource = HikariCP.init(
-    url = "jdbc:h2:mem:db;DB_CLOSE_DELAY=-1;MODE=PostgreSQL",
-    username = "sa",
-    password = "sa"
+    url = postgres14Container.jdbcUrl,
+    username = postgres14Container.username,
+    password = postgres14Container.password
 ) {
     maximumPoolSize = 2
 }
+
+fun resetTestDatabase() {
+    val query = "truncate table aktivitetsplan_melding, hendelse_melding_feilet, aktivitetsplan_id"
+    using(sessionOf(testDataSource)) { session ->
+        session.run(queryOf(query).asUpdate)
+    }
+}
+


### PR DESCRIPTION
Det er allerede bruk av testcontainers for å sette opp kafka i tester. Vi kan gjøre testene våre mer prod-like ved å bruke testcontainers for databasen også.