### PR TITLE
Kan også resende usendte meldinger

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/tiltakhendelseaktivitetsplan/App.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/tiltakhendelseaktivitetsplan/App.kt
@@ -91,12 +91,14 @@ class App(
                                 ?: throw IllegalArgumentException("Avtale-id mangler i forespørselen")
                         )
                         database.hentEntitet(avtaleId)
-                            .filter { it.sendt }
                             .maxByOrNull { it.opprettetTidspunkt }
                             ?.let {
                                 logger.info(
                                     "Sender melding ${it.id} på ny for avtale ${avtaleId}"
                                 )
+                                if (!it.sendt) {
+                                    logger.info("Siste melding for avtale ${avtaleId} har ikke blitt sendt tidligere")
+                                }
                                 avtaleHendelseConsumer.kallProducer(it)
                             }
                         call.respond(HttpStatusCode.NoContent)


### PR DESCRIPTION
Endepunkt for resending av "siste melding" i
aktivitetsplan filtrerte tidligere bort meldinger
som ikke har blitt sendt tidligere. Men grunnet en opprydning i forrige uke hvor kafka var ustabilt
har vi mange avtaler hvor siste melding aldri ble
sendt.

Derfor er det jo lurt at man også kan sende disse. Vi fjerner derfor filteret på "sendt" og sier at
den siste meldingen på avtaler alltid kan sendes.